### PR TITLE
feat: show per-step progress with TTS chunk tracking

### DIFF
--- a/url-processor/public/index.html
+++ b/url-processor/public/index.html
@@ -112,10 +112,10 @@
             font-size: 12px;
             color: #666;
             display: flex;
-            align-items: center;
+            align-items: flex-start;
             gap: 8px;
         }
-        
+
         .status-indicator {
             display: inline-block;
             width: 8px;
@@ -123,39 +123,86 @@
             border-radius: 50%;
             margin-right: 5px;
         }
-        
+
         .status-not-started { background-color: #6c757d; }
         .status-processing { background-color: #ffc107; animation: pulse 1.5s infinite; }
         .status-completed { background-color: #28a745; }
         .status-error { background-color: #dc3545; }
-        
+
         @keyframes pulse {
             0%, 100% { opacity: 1; }
             50% { opacity: 0.5; }
         }
-        
-        .progress-bar {
-            width: 100px;
+
+        .steps-progress {
+            flex: 1;
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+        }
+
+        .step-item {
+            display: flex;
+            flex-direction: column;
+        }
+
+        .step-label {
+            font-size: 12px;
+            margin-bottom: 2px;
+        }
+
+        .step-bar {
+            width: 100%;
             height: 4px;
             background-color: #e9ecef;
             border-radius: 2px;
             overflow: hidden;
-            margin-right: 10px;
         }
-        
-        .progress-fill {
+
+        .step-fill {
             height: 100%;
+            width: 0;
             background-color: #007bff;
             transition: width 0.3s ease;
-            border-radius: 2px;
         }
-        
-        .progress-fill.completed {
+
+        .step-fill.completed {
             background-color: #28a745;
+            width: 100%;
         }
-        
-        .progress-fill.processing {
+
+        .step-fill.processing {
             background-color: #ffc107;
+        }
+
+        .chunk-progress {
+            display: flex;
+            gap: 2px;
+            margin-top: 4px;
+        }
+
+        .chunk-bar {
+            flex: 1;
+            height: 4px;
+            background-color: #e9ecef;
+            border-radius: 2px;
+            overflow: hidden;
+        }
+
+        .chunk-fill {
+            height: 100%;
+            width: 0;
+            background-color: #007bff;
+        }
+
+        .chunk-fill.completed {
+            background-color: #28a745;
+            width: 100%;
+        }
+
+        .chunk-fill.processing {
+            background-color: #ffc107;
+            width: 100%;
         }
         
         .url-actions {
@@ -636,7 +683,70 @@
                 showStatus('Copied to clipboard!', 'success');
             }
         }
-        
+
+        function generateStepBars(status) {
+            const steps = [
+                { id: 1, label: 'Store URL info' },
+                { id: 2, label: 'Fetch HTML' },
+                { id: 3, label: 'Process content' },
+                { id: 4, label: 'Extract text' },
+                { id: 5, label: 'Generate audio' }
+            ];
+
+            return steps.map(step => {
+                let fillWidth = 0;
+                let fillClass = '';
+                let chunkHtml = '';
+
+                if (step.id < 5) {
+                    if (status.step >= step.id) {
+                        fillWidth = 100;
+                        fillClass = 'completed';
+                    } else if (status.step + 1 === step.id && status.status === 'processing') {
+                        fillWidth = 50;
+                        fillClass = 'processing';
+                    }
+                } else {
+                    if (status.status === 'completed') {
+                        fillWidth = 100;
+                        fillClass = 'completed';
+                    } else if (status.audioProgress) {
+                        const progress = status.audioProgress;
+                        fillWidth = progress.status === 'generating'
+                            ? Math.round((progress.currentChunk / progress.totalChunks) * 100)
+                            : 100;
+                        fillClass = 'processing';
+
+                        const chunks = Array.from({ length: progress.totalChunks }).map((_, i) => {
+                            let chunkClass = '';
+                            if (progress.status === 'concatenating') {
+                                chunkClass = 'completed';
+                            } else if (i < progress.currentChunk - 1) {
+                                chunkClass = 'completed';
+                            } else if (i === progress.currentChunk - 1) {
+                                chunkClass = 'processing';
+                            }
+                            return `<div class="chunk-bar"><div class="chunk-fill ${chunkClass}" style="width:${chunkClass ? '100' : '0'}%"></div></div>`;
+                        }).join('');
+                        chunkHtml = `<div class="chunk-progress">${chunks}</div>`;
+                    } else if (status.step + 1 === step.id && status.status === 'processing') {
+                        fillWidth = 50;
+                        fillClass = 'processing';
+                    }
+                }
+
+                return `
+                    <div class="step-item">
+                        <span class="step-label">${step.label}</span>
+                        <div class="step-bar">
+                            <div class="step-fill ${fillClass}" style="width:${fillWidth}%"></div>
+                        </div>
+                        ${step.id === 5 ? chunkHtml : ''}
+                    </div>
+                `;
+            }).join('');
+        }
+
         // Render URLs list
         function renderUrls() {
             const container = document.getElementById('urlListContainer');
@@ -658,23 +768,8 @@
                 };
                 
                 const statusClass = `status-${status.status}`;
-                const progressClass = status.status === 'completed' ? 'completed' : 
-                                    status.status === 'processing' ? 'processing' : '';
-                
-                // Handle detailed audio progress
-                let displayStepName = status.stepName;
-                let detailedProgress = status.progress;
-                
-                if (status.audioProgress && status.audioProgress.status === 'generating') {
-                    const audioProgress = status.audioProgress;
-                    const chunkProgressPercent = Math.round((audioProgress.currentChunk / audioProgress.totalChunks) * 100);
-                    detailedProgress = 80 + (chunkProgressPercent * 0.2); // Scale to 80-100% for step 5
-                    displayStepName = `Generating audio (${audioProgress.currentChunk}/${audioProgress.totalChunks})`;
-                } else if (status.audioProgress && status.audioProgress.status === 'concatenating') {
-                    detailedProgress = 95;
-                    displayStepName = 'Concatenating audio files';
-                }
-                
+                const stepBars = generateStepBars(status);
+
                 // Format dates
                 const addedDateStr = addedAt ? new Date(addedAt).toLocaleString() : 'Unknown';
                 
@@ -687,10 +782,7 @@
                             </div>
                             <div class="url-status">
                                 <span class="status-indicator ${statusClass}"></span>
-                                <div class="progress-bar">
-                                    <div class="progress-fill ${progressClass}" style="width: ${detailedProgress}%"></div>
-                                </div>
-                                <span>${displayStepName} (${Math.round(detailedProgress)}%)</span>
+                                <div class="steps-progress">${stepBars}</div>
                             </div>
                         </div>
                         <div class="url-actions">


### PR DESCRIPTION
## Summary
- replace single progress bar with per-step indicators
- add chunk-level progress tracking for TTS generation

## Testing
- `npm test -- --passWithNoTests` *(fails: ffmpeg missing; rss.test.js contains no tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b1e5d1a3108326be94dbcf007aacdd